### PR TITLE
ci: use Circle CI's Node LTS image to release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,23 @@ orbs:
 
 jobs:
   release:
-    executor: cypress/base-10
+    docker:
+      - image: circleci/node:lts
+    working_directory: ~/repo
     steps:
-      - attach_workspace:
-          at: ~/
+      - checkout
+      - restore_cache:
+          name: Restore Yarn Package Cache
+          keys:
+            - yarn-packages-{{ checksum "yarn.lock" }}
+      - run:
+          name: Install Dependencies
+          command: yarn install --frozen-lockfile
+      - save_cache:
+          name: Save Yarn Package Cache
+          key: yarn-packages-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache
       - run: yarn semantic-release
 
 workflows:


### PR DESCRIPTION
This should work around the issue where using the Cypress orb hangs at the following:

```
The authenticity of host 'github.com (192.30.253.113)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)?
```