### PR TITLE
revert: build(ts): enable skipLibCheck hack to avoid issues with Cypress types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,9 +7,7 @@
     "noEmit": true,
     "strict": true,
     "types": ["cypress", "@testing-library/cypress", "cypress-axe"],
-    "typeRoots": ["node_modules/@types", "./src/@types"],
-    // TODO: remove once Cypress types are sorted out
-    "skipLibCheck": true
+    "typeRoots": ["node_modules/@types", "./src/@types"]
   },
   "exclude": [".cache", "public"]
 }


### PR DESCRIPTION
This reverts commit 844fca738434f7416e3b91cf0ae88cc75d84811d.