### PR TITLE
ci(cypress): run E2E tests in CI against production build rather than develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
       - cypress/run:
           executor: cypress/base-14-7-0
           yarn: true
-          start: yarn develop
+          start: yarn serve
           wait-on: '--timeout 40000 http://localhost:8000'
       - validate:
           requires:


### PR DESCRIPTION
For real this time.