### PR TITLE
refactor: migrate font from Source Sans Pro to Source Sans 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/parser": "7.22.5",
         "@babel/plugin-syntax-jsx": "7.22.5",
         "@fontsource/nunito": "5.0.3",
-        "@fontsource/source-sans-pro": "5.0.3",
+        "@fontsource/source-sans-3": "5.0.3",
         "@testing-library/cypress": "9.0.0",
         "@types/lodash": "4.14.195",
         "@types/ms": "0.7.31",
@@ -2099,10 +2099,10 @@
       "resolved": "https://registry.npmjs.org/@fontsource/nunito/-/nunito-5.0.3.tgz",
       "integrity": "sha512-NhWeAgtKjGtcAsZulNzaYFIXuX9SKiUjWE5L4tsrvr/Dfu2vWgnjOwL7GX0tvJ4go1bymwVLuQI27OcxHwMPvQ=="
     },
-    "node_modules/@fontsource/source-sans-pro": {
+    "node_modules/@fontsource/source-sans-3": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-pro/-/source-sans-pro-5.0.3.tgz",
-      "integrity": "sha512-mQnjuif/37VxwRloHZ+wQdoozd2VPWutbFSt1AuSkk7nFXIBQxHJLw80rgCF/osL0t7N/3Gx1V7UJuOX2zxzhQ=="
+      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-3/-/source-sans-3-5.0.3.tgz",
+      "integrity": "sha512-5oQh3zLBiWpv2v50X2cq1iqJ2LG9M6XjGdWZJHs8LYfUFj+YenK5LzSE7sx9p4NFMtZFSNQAsc8CKdHHxzMXjA=="
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -16968,10 +16968,10 @@
       "resolved": "https://registry.npmjs.org/@fontsource/nunito/-/nunito-5.0.3.tgz",
       "integrity": "sha512-NhWeAgtKjGtcAsZulNzaYFIXuX9SKiUjWE5L4tsrvr/Dfu2vWgnjOwL7GX0tvJ4go1bymwVLuQI27OcxHwMPvQ=="
     },
-    "@fontsource/source-sans-pro": {
+    "@fontsource/source-sans-3": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-pro/-/source-sans-pro-5.0.3.tgz",
-      "integrity": "sha512-mQnjuif/37VxwRloHZ+wQdoozd2VPWutbFSt1AuSkk7nFXIBQxHJLw80rgCF/osL0t7N/3Gx1V7UJuOX2zxzhQ=="
+      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-3/-/source-sans-3-5.0.3.tgz",
+      "integrity": "sha512-5oQh3zLBiWpv2v50X2cq1iqJ2LG9M6XjGdWZJHs8LYfUFj+YenK5LzSE7sx9p4NFMtZFSNQAsc8CKdHHxzMXjA=="
     },
     "@hapi/hoek": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/parser": "7.22.5",
     "@babel/plugin-syntax-jsx": "7.22.5",
     "@fontsource/nunito": "5.0.3",
-    "@fontsource/source-sans-pro": "5.0.3",
+    "@fontsource/source-sans-3": "5.0.3",
     "@testing-library/cypress": "9.0.0",
     "@types/lodash": "4.14.195",
     "@types/ms": "0.7.31",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import '@fontsource/nunito/latin-700.css';
-import '@fontsource/source-sans-pro/latin-300.css';
-import '@fontsource/source-sans-pro/latin-400.css';
+import '@fontsource/source-sans-3/latin-300.css';
+import '@fontsource/source-sans-3/latin-400.css';
 import { Routes, Route } from 'react-router-dom';
 import Layout from './layout';
 import HomePage from './home-page';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        body: ['Source Sans Pro', ...defaultTheme.fontFamily.sans],
+        body: ['"Source Sans 3"', ...defaultTheme.fontFamily.sans],
         heading: ['Nunito', ...defaultTheme.fontFamily.sans],
         mono: ['Courier New', 'Courier', 'monospace'],
       },


### PR DESCRIPTION
Source Sans Pro seems to have been replaced with Source Sans 3 in the Google Fonts directory. I can only assume SSP is deprecated or something.